### PR TITLE
Adjust output formatting and associated command line options

### DIFF
--- a/etc/config.yaml.reference
+++ b/etc/config.yaml.reference
@@ -21,32 +21,20 @@ base_url:
 jwt_token:
 
 # =============================================================================
-# Printing Mode [OPTIONAL]
-# Specify one of the following modes: stdout, stderr, status, verbose
+# Default streams to print
+# Specify which streams to print by default.
 #
-# The stdout, stderr, and status modes will only print their respective
-# attributes only (E.g. stdout mode will only print standard out).
-#
-# Verbose will print all three attributes: stdout, stderr, and status. This
-# field will default to verbose unless otherwise set.
-#
-# This field can be overridden on the command line using the
-# flags of the same names: --stdout, --stderr, --status, --verbose
+# These fields can be overridden on the command line using the flags:
+#   --[no-]stdout, --[no-]stderr
 # =============================================================================
-printing_mode: verbose
-
-# =============================================================================
-# Printing Mode when Called with --output [OPTIONAL]
-# Similar to the 'print_mode' config option, but acts as the default when the
-# application is called with --output. The field defaults to verbose unless
-# otherwise set.
-# =============================================================================
-output_printing_mode: status
+print_stdout: true
+print_stderr: true
 
 # =============================================================================
 # Hide Print Flags [OPTIONAL]
-# Hides the print flags from the CLI. This means the print_mode and
-# output_print_mode options will solely determine how the application prints
+# Hides the print flags from the CLI. This means the print_stdout and
+# print_stderr configuration options will solely determine how the application
+# prints
 # =============================================================================
 hide_print_flags:
 

--- a/lib/action_client/cli.rb
+++ b/lib/action_client/cli.rb
@@ -139,7 +139,8 @@ module ActionClient
             end
             c.action do |args, opts|
               with_error_handling do
-                opts.default(prefix: true, group: false)
+                opts.default(group: false)
+                opts.default(prefix: opts.group)
                 hash_opts = opts.__hash__.tap { |h| h.delete(:trace) }
                 run_remote_action(cmd.name, args.first, **hash_opts)
               end

--- a/lib/action_client/cli.rb
+++ b/lib/action_client/cli.rb
@@ -105,45 +105,7 @@ module ActionClient
         raise UnexpectedError, ticket.errors.full_messages
       end
 
-      ticket.jobs.each do |job|
-        if output
-          FileUtils.mkdir_p(output)
-
-          # Save Status
-          path = File.expand_path("#{job.node.id}.status", output)
-          File.write(path, job.status)
-
-          # Save Stdout
-          path = File.expand_path("#{job.node.id}.stdout", output)
-          File.write(path, job.stdout)
-
-          # Save Stderr
-          path = File.expand_path("#{job.node.id}.stderr", output)
-          File.write(path, job.stderr)
-        end
-
-        case mode
-        when :status
-          puts "#{job.node.id}: #{job.status}"
-        when :stdout
-          puts "#{job.node.id}: #{job.stdout}"
-        when :stderr
-          puts "#{job.node.id}: #{job.stderr}"
-        when :verbose
-          puts <<~JOB
-
-            NODE: #{job.node.name}
-            STATUS: #{job.status}
-            STDOUT:
-            #{job.stdout}
-
-            STDERR:
-            #{job.stderr}
-          JOB
-        else
-          raise UnexpectedError
-        end
-      end
+      Formatter.new(ticket.jobs, mode, output).run
     end
 
     begin

--- a/lib/action_client/cli.rb
+++ b/lib/action_client/cli.rb
@@ -105,7 +105,9 @@ module ActionClient
         raise UnexpectedError, ticket.errors.full_messages
       end
 
-      Formatter.new(ticket.jobs, mode, output).run
+      Formatter
+        .new(jobs: ticket.jobs, mode: mode, output_dir: output)
+        .run
     end
 
     begin

--- a/lib/action_client/config.rb
+++ b/lib/action_client/config.rb
@@ -61,9 +61,9 @@ module ActionClient
     property :jwt_token, default: ''
     property :debug
 
-    property :printing_mode, default: :verbose, transform_with: ->(v) { v.to_sym }
-    property :output_printing_mode, default: :status, transform_with: ->(v) { v.to_sym }
     property :hide_print_flags
+    property :print_stdout, default: true
+    property :print_stderr, default: true
 
     [:debug, :hide_print_flags].each do |m|
       define_method("#{m}?") { public_send(m) ? true : false }

--- a/lib/action_client/formatter.rb
+++ b/lib/action_client/formatter.rb
@@ -46,7 +46,7 @@ module ActionClient
     def print_tagged_streams(job)
       Array.wrap(@streams).each do |stream|
         lines = tagged_lines(job, stream)
-        puts lines.join unless lines.empty?
+        io_for_stream(stream).puts lines.join unless lines.empty?
       end
     end
 
@@ -73,6 +73,12 @@ module ActionClient
       # Save Stderr
       path = File.expand_path("#{job.node.id}.stderr", @output_dir)
       File.write(path, job.stderr)
+    end
+
+    def io_for_stream(stream)
+      Kernel.const_get(stream.to_s.upcase)
+    rescue NameError
+      STDOUT
     end
   end
 end

--- a/lib/action_client/formatter.rb
+++ b/lib/action_client/formatter.rb
@@ -29,10 +29,11 @@
 
 module ActionClient
   class Formatter
-    def initialize(jobs:, mode:, output_dir:)
+    def initialize(jobs:, mode:, output_dir:, prefix:)
       @jobs = jobs
       @mode = mode
       @output_dir = output_dir
+      @prefix = prefix
     end
 
     def run
@@ -62,6 +63,8 @@ module ActionClient
     end
 
     def tagged_lines(job, stream)
+      return job.send(stream).lines unless @prefix
+
       tag = job.node.id
       job.send(stream).lines.map do |line|
         "#{tag}: #{line}"

--- a/lib/action_client/formatter.rb
+++ b/lib/action_client/formatter.rb
@@ -29,9 +29,9 @@
 
 module ActionClient
   class Formatter
-    def initialize(jobs:, mode:, output_dir:, prefix:)
+    def initialize(jobs:, streams: %w(stdout stderr), output_dir:, prefix:)
       @jobs = jobs
-      @mode = mode
+      @streams = streams
       @output_dir = output_dir
       @prefix = prefix
     end
@@ -39,26 +39,14 @@ module ActionClient
     def run
       @jobs.each do |job|
         persist_output(job) if @output_dir
-
-        case @mode
-        when :status
-          puts "#{job.node.id}: #{job.status}"
-        when :stdout
-          puts_tagged_streams(job, :stdout)
-        when :stderr
-          puts_tagged_streams(job, :stderr)
-        when :verbose
-          puts_tagged_streams(job)
-        else
-          raise UnexpectedError
-        end
+        print_tagged_streams(job)
       end
     end
 
-    def puts_tagged_streams(job, streams=%w(stdout stderr))
-      Array.wrap(streams).each do |stream|
-        output = tagged_lines(job, stream)
-        puts output.join unless output.empty?
+    def print_tagged_streams(job)
+      Array.wrap(@streams).each do |stream|
+        lines = tagged_lines(job, stream)
+        puts lines.join unless lines.empty?
       end
     end
 


### PR DESCRIPTION
This PR changes to the output formatting and the associated command line options.

### dshbak compatible output

A `--prefix` switch has been added to prefix each line of output with the name of the node.  This produces `dshbak` compatible output.  When operating on a node there is not much use in sending the output to `dshbak` so it defaults to off.  When operating on a group of nodes (including a group of one node) the prefix defaults to on.

### Output for a node

Previously, running the sample script across a single node would produce the following output.

```
$ ./bin/flight-action sample node1 

NODE: node1
STATUS: 0
STDOUT:
Running the metal script for: node1
Doing metal stuff ....
Done


STDERR:
Some stderr output

```

Now the output is as follows:

```
$ ./bin/flight-action sample node1 
Running the metal script for: node1
Doing metal stuff ....
Done
Some stderr output
```

Instead of prefixing the standard output and standard error with a header they are sent to the respective streams, allowing them to be disambiguated via the usual stream redirection mechanisms.


### Output for a group

Previously, running the sample script across a group of, say, two nodes would produce the following output.

```
$ ./bin/flight-action sample -g node1,node2

NODE: node1
STATUS: 0
STDOUT:
Running the metal script for: node1
Doing metal stuff ....
Done


STDERR:
Some stderr output


NODE: node2
STATUS: 0
STDOUT:
Running the metal script for: node2
Doing metal stuff ....
Done


STDERR:
Some stderr output

```

Now the output is as follows:

```
$ ./bin/flight-action sample -g node1,node2
node1: Running the metal script for: node1
node1: Doing metal stuff ....
node1: Done
node1: Some stderr output
node2: Running the metal script for: node2
node2: Doing metal stuff ....
node2: Done
node2: Some stderr output
```

### Filtering stdout and stderr

The standard output for each job is sent to `flight-action`'s standard output stream.  Similarly, the standard error for each job is sent to `flight-action`'s standard error stream.  This allows the usual stream redirection mechanisms to be used to disambiguate them.

Additionally, the streams can be silenced via the `--no-stdout` and `--no-stderr` flags.

### Obtaining the status for the jobs

Support for printing the exit codes of the jobs has been removed.  Exit codes don't really fit in to output printing in a nice way.  The exit codes are still saved to the filesystem if the `--output DIRECTORY` option is given.

There is also a `-S` option which causes the program to exit with the max exit code of the commands it executed.  When running a job on a single node, this will provide a very simple and intuitive way to get the exit code for the remote command.